### PR TITLE
Feature/deeple source language

### DIFF
--- a/Classes/Utility/Translator.php
+++ b/Classes/Utility/Translator.php
@@ -195,10 +195,11 @@ class Translator {
             $toTranslateObject = array_intersect_key($record, array_flip($columns));
 
             $toTranslate = array_filter($toTranslateObject, fn($value) => !is_null($value) && $value !== '');
+            $deeplSourceLang = $this->deeplSourceLanguage($targetLanguageUid);
             $deeplTargetLang = $this->deeplTargetLanguage($targetLanguageUid);
             if (count($toTranslate) > 0 && $deeplTargetLang !== null) {
                 $translator = new \DeepL\Translator($this->apiKey);
-                $result = $translator->translateText($toTranslate, null , $deeplTargetLang, [TranslateTextOptions::TAG_HANDLING => 'html']);
+                $result = $translator->translateText($toTranslate, $deeplSourceLang, $deeplTargetLang, [TranslateTextOptions::TAG_HANDLING => 'html']);
             }
 
             $keys = array_keys($toTranslate);
@@ -219,6 +220,21 @@ class Translator {
         }
 
         return $translatedColumns;
+    }
+
+    /**
+     * @param int $languageId
+     * @return string|null
+     */
+    private function deeplSourceLanguage(int $languageId): ?string
+    {
+        foreach ($this->siteLanguages as $language) {
+            if ($language['languageId'] == $languageId) {
+                return $language['deeplSourceLang'] ?? null;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/Configuration/SiteConfiguration/Overrides/sites.php
+++ b/Configuration/SiteConfiguration/Overrides/sites.php
@@ -119,6 +119,33 @@ if (!empty($translateableTables)) {
     $GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'] .= ', --div--;Autotranslate' . $showItem;
 }
 
+// settings for deepl translation source
+$deeplSourceLangItems = [];
+$apiKey = TranslationHelper::apiKey();
+if (empty($apiKey)) {
+    $deeplSourceLangItems[] = ['Please define deepl api key first', ''];
+} else {
+    $deeplSourceLangItems[] = ['Please Choose'];
+    $translator = new \DeepL\Translator($apiKey);
+    $sourceLanguages = $translator->getSourceLanguages();
+    foreach ($sourceLanguages as $sourceLanguage) {
+        $deeplSourceLangItems[] = [$sourceLanguage->name, $sourceLanguage->code];
+    }
+}
+
+$GLOBALS['SiteConfiguration']['site_language']['columns']['deeplSourceLang'] = [
+    'label' => 'Source language (Iso code)',
+    'description' => 'Select source languages to use for DeepL for translating a record',
+    'config' => [
+        'type' => 'select',
+        'renderType' => 'selectSingle',
+        'items' => $deeplSourceLangItems,
+        'minitems' => 0,
+        'maxitems' => 1,
+        'size' => 1,
+    ],
+];
+
 // settings for deepl translation target
 $deeplTargetLangItems = [];
 $apiKey = TranslationHelper::apiKey();
@@ -147,7 +174,7 @@ $GLOBALS['SiteConfiguration']['site_language']['columns']['deeplTargetLang'] = [
 ];
 
 $GLOBALS['SiteConfiguration']['site_language']['palettes']['autotranslate'] = [
-    'showitem' => 'deeplTargetLang',
+    'showitem' => 'deeplSourceLang,deeplTargetLang',
 ];
 
 $GLOBALS['SiteConfiguration']['site_language']['types']['1']['showitem'] = str_replace(


### PR DESCRIPTION
**Problem:**

Sometimes deepl auto detection for the source language does not work correctly. E.g. if I want to translate a field that contains only the single word "Impressum" in our default language "de" deeple detects that as language "it" and translation fails.

**Solution:**

Make it possible to configure the source language in the site config and use it if set.