### PR TITLE
[BUGFIX] Undefined variable $result in /var/www/vendor/thieleundklose…

### DIFF
--- a/Classes/Utility/Translator.php
+++ b/Classes/Utility/Translator.php
@@ -228,6 +228,7 @@ class Translator implements LoggerAwareInterface
             $toTranslate = array_filter($toTranslateObject, fn($value) => !is_null($value) && $value !== '');
             $deeplSourceLang = $this->deeplSourceLanguage();
             $deeplTargetLang = $this->deeplTargetLanguage($targetLanguageUid);
+            $result = null;
             if (count($toTranslate) > 0 && $deeplTargetLang !== null) {
                 $translator = new \DeepL\Translator($this->apiKey);
                 $result = $translator->translateText($toTranslate, $deeplSourceLang, $deeplTargetLang, [TranslateTextOptions::TAG_HANDLING => 'html']);


### PR DESCRIPTION
…/autotranslate/Classes/Utility/Translator.php line 247

This fixes the error

Core: Error handler (BE): PHP Warning: Undefined variable $result in /var/www/vendor/thieleundklose/autotranslate/Classes/Utility/Translator.php line 247