### PR TITLE
Propagate "pi_flexform" field for new elements

### DIFF
--- a/Classes/Utility/Translator.php
+++ b/Classes/Utility/Translator.php
@@ -246,6 +246,10 @@ class Translator implements LoggerAwareInterface
             $translatedColumns['hidden'] = $record['hidden'];
             $translatedColumns[self::AUTOTRANSLATE_LAST] = time();
 
+            if (isset($record['pi_flexform'])) {
+                $translatedColumns['pi_flexform'] = $record['pi_flexform'];
+            }
+
             LogUtility::log($this->logger, 'Successful translated to target language {deeplTargetLang}.', ['deeplTargetLang' => $deeplTargetLang, 'toTranslate' => $toTranslate, 'result' => $result, 'translatedColumns' => $translatedColumns]);
         } catch (\Exception $e) {
             LogUtility::log($this->logger, 'Translation Error: {error}.', ['error' => $e->getMessage()], LogUtility::MESSAGE_ERROR);


### PR DESCRIPTION
If you translate elements that contain a "pi_flexform", e.g. "buepro/typo3-container-elements", the flexform values ​​are not adopted, so you have to reset them after translation, which is simply not possible for very many pages. The change adopts the flexform settings directly into the translated element.