### PR TITLE
fix: CLI `quiet` leak

### DIFF
--- a/Classes/Command/BatchTranslation.php
+++ b/Classes/Command/BatchTranslation.php
@@ -110,7 +110,7 @@ final class BatchTranslation extends Command implements LoggerAwareInterface
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (PHP_SAPI === 'cli') {
-            echo 'Running from CLI, setting application type to BE' . PHP_EOL;
+            $output->writeln('Running from CLI, setting application type to BE' . PHP_EOL);
 
             // https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/DataHandler/UsingDataHandler/Index.html#dataHandler-cli-command
             Bootstrap::initializeBackendAuthentication();


### PR DESCRIPTION
`$ php vendor/bin/typo3 --quiet autotranslate:batch:run`

"Running from CLI, setting application type to BE" => `NULL`