### PR TITLE
Fix cache roundtrip losing translations (root cause of #94)

### DIFF
--- a/Build/UnitTests.xml
+++ b/Build/UnitTests.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
+    bootstrap="../.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
+    colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>../Tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/Classes/Service/TranslationCacheService.php
+++ b/Classes/Service/TranslationCacheService.php
@@ -178,20 +178,26 @@ class TranslationCacheService
                 $results[$index] = null;
                 continue;
             }
-            
-            // Create TextResult-like object (since TextResult constructor is protected)
-            $result = new class($data['text'], $data['detected_source_lang']) {
-                public $text;
-                public $detectedSourceLang;
-                public $billedCharacters;
 
-                public function __construct(string $text, ?string $detectedSourceLang) {
-                    $this->text = $text;
-                    $this->detectedSourceLang = $detectedSourceLang;
+            $constructor = new \ReflectionMethod(TextResult::class, '__construct');
+            if ($constructor->getNumberOfRequiredParameters() >= 3) {
+                $results[$index] = new TextResult(
+                    $data['text'],
+                    $data['detected_source_lang'] ?? '',
+                    $data['billed_characters'] ?? 0
+                );
+            } else {
+                $result = new TextResult(
+                    $data['text'],
+                    $data['detected_source_lang'] ?? ''
+                );
+
+                if (property_exists($result, 'billedCharacters')) {
+                    $result->billedCharacters = $data['billed_characters'] ?? 0;
                 }
-            };
-            $result->billedCharacters = $data['billed_characters'];
-            $results[$index] = $result;
+
+                $results[$index] = $result;
+            }
         }
         return $results;
     }

--- a/Tests/Unit/Service/TranslationCacheServiceTest.php
+++ b/Tests/Unit/Service/TranslationCacheServiceTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThieleUndKlose\Autotranslate\Tests\Unit\Service;
+
+use DeepL\TextResult;
+use PHPUnit\Framework\TestCase;
+use ThieleUndKlose\Autotranslate\Service\TranslationCacheService;
+
+/**
+ * Unit tests for TranslationCacheService serialization.
+ *
+ * Verifies that the serialize/unserialize roundtrip for DeepL TextResult
+ * objects preserves all data. This is the regression test for issue #94:
+ * unserializeTextResults() created anonymous classes instead of real
+ * TextResult objects, causing serializeTextResults() to discard them
+ * on re-serialization (instanceof TextResult check fails for anonymous classes).
+ *
+ * @see https://github.com/thieleundklose/tk-typo3-autotranslate/issues/94
+ */
+final class TranslationCacheServiceTest extends TestCase
+{
+    private TranslationCacheService $service;
+    private \ReflectionMethod $serialize;
+    private \ReflectionMethod $unserialize;
+
+    protected function setUp(): void
+    {
+        $reflection = new \ReflectionClass(TranslationCacheService::class);
+        $this->service = $reflection->newInstanceWithoutConstructor();
+
+        $this->serialize = $reflection->getMethod('serializeTextResults');
+        $this->serialize->setAccessible(true);
+
+        $this->unserialize = $reflection->getMethod('unserializeTextResults');
+        $this->unserialize->setAccessible(true);
+    }
+
+    /**
+     * Verifies that a single serialize → unserialize roundtrip preserves
+     * the translated text, detected source language, and billed characters.
+     */
+    public function testSingleRoundtripPreservesData(): void
+    {
+        $original = [
+            new TextResult('Hallo Welt', 'de', 10),
+            new TextResult('Bonjour le monde', 'fr', 16),
+        ];
+
+        $serialized = $this->serialize->invoke($this->service, $original);
+        $unserialized = $this->unserialize->invoke($this->service, $serialized);
+
+        self::assertSame('Hallo Welt', $unserialized[0]->text);
+        self::assertSame('de', $unserialized[0]->detectedSourceLang);
+        self::assertSame(10, $unserialized[0]->billedCharacters);
+
+        self::assertSame('Bonjour le monde', $unserialized[1]->text);
+        self::assertSame('fr', $unserialized[1]->detectedSourceLang);
+        self::assertSame(16, $unserialized[1]->billedCharacters);
+    }
+
+    /**
+     * Verifies that a double roundtrip (serialize → unserialize → serialize
+     * → unserialize) preserves all data. This is the exact scenario that
+     * triggered issue #94: partial cache hits are unserialized, then mixed
+     * with fresh TextResult objects and re-serialized as a complete cache entry.
+     *
+     * Without the fix, the second serialize() converts the anonymous class
+     * objects from the first unserialize() to null (instanceof TextResult fails).
+     */
+    public function testDoubleRoundtripPreservesData(): void
+    {
+        $original = [
+            new TextResult('Hello World', 'en', 11),
+            new TextResult('Bonjour', 'fr', 7),
+        ];
+
+        // First roundtrip
+        $serialized1 = $this->serialize->invoke($this->service, $original);
+        $unserialized1 = $this->unserialize->invoke($this->service, $serialized1);
+
+        // Second roundtrip (this is where the bug manifests)
+        $serialized2 = $this->serialize->invoke($this->service, $unserialized1);
+        $unserialized2 = $this->unserialize->invoke($this->service, $serialized2);
+
+        self::assertNotNull($serialized2[0], 'Re-serialized entry must not be null');
+        self::assertNotNull($serialized2[1], 'Re-serialized entry must not be null');
+
+        self::assertSame('Hello World', $serialized2[0]['text']);
+        self::assertSame('Bonjour', $serialized2[1]['text']);
+
+        self::assertSame('Hello World', $unserialized2[0]->text);
+        self::assertSame('Bonjour', $unserialized2[1]->text);
+    }
+
+    /**
+     * Verifies that null values in the result array are preserved through
+     * the roundtrip. Null entries represent translation failures and must
+     * remain null, not be converted to empty TextResult objects.
+     */
+    public function testNullValuesArePreservedThroughRoundtrip(): void
+    {
+        $original = [
+            new TextResult('Hello', 'en', 5),
+            null,
+            new TextResult('World', 'en', 5),
+        ];
+
+        $serialized = $this->serialize->invoke($this->service, $original);
+        $unserialized = $this->unserialize->invoke($this->service, $serialized);
+
+        self::assertNotNull($unserialized[0]);
+        self::assertSame('Hello', $unserialized[0]->text);
+        self::assertNull($unserialized[1], 'Null entries must remain null');
+        self::assertNotNull($unserialized[2]);
+        self::assertSame('World', $unserialized[2]->text);
+    }
+
+    /**
+     * Verifies that unserialized results are instances of DeepL\TextResult,
+     * not anonymous classes. This ensures compatibility with instanceof
+     * checks throughout the codebase, particularly in serializeTextResults().
+     */
+    public function testUnserializedResultsAreTextResultInstances(): void
+    {
+        $original = [new TextResult('Test', 'en', 4)];
+
+        $serialized = $this->serialize->invoke($this->service, $original);
+        $unserialized = $this->unserialize->invoke($this->service, $serialized);
+
+        self::assertInstanceOf(TextResult::class, $unserialized[0]);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">= 7.4 < 8.5"
     },
     "require-dev": {
-        "typo3/testing-framework": "^6.8"
+        "typo3/testing-framework": "^6.8 || ^7.0 || ^8.2 || ^9.0"
     },
     "autoload": {
         "psr-4": {
@@ -34,11 +34,25 @@
     },
     "config": {
         "vendor-dir": ".Build/vendor",
-        "bin-dir": ".Build/bin"
+        "bin-dir": ".Build/bin",
+        "allow-plugins": {
+            "typo3/cms-composer-installers": true,
+            "typo3/class-alias-loader": true
+        }
     },
     "scripts": {
         "post-autoload-dump": [
             "TYPO3\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare"
+        ],
+        "ci:test:php:unit": [
+            "phpunit --configuration Build/UnitTests.xml"
+        ],
+        "ci:test:php:functional": [
+            "phpunit --configuration Build/FunctionalTests.xml"
+        ],
+        "ci:test": [
+            "@ci:test:php:unit",
+            "@ci:test:php:functional"
         ]
     },
     "extra": {


### PR DESCRIPTION
## Summary

- Fix root cause of #94: `unserializeTextResults()` created anonymous classes instead of `DeepL\TextResult` objects, causing `serializeTextResults()` to silently discard them on re-serialization
- Add unit tests for the serialize/unserialize roundtrip
- Add CI composer scripts (`ci:test`, `ci:test:php:unit`, `ci:test:php:functional`)
- Broaden `testing-framework` constraint to `^6.8 || ^7.0 || ^8.2 || ^9.0` for TYPO3 11-13

## Root Cause

`unserializeTextResults()` created anonymous class objects because it assumed `TextResult`'s constructor was protected (see comment at line 182). In fact, the constructor is public:

```php
// TextResult constructor is public
public function __construct(string $text, string $detectedSourceLang, int $billedCharacters, ?string $modelTypeUsed = null)
```

The anonymous class objects failed the `instanceof TextResult` check in `serializeTextResults()`, so they were serialized as `null`. This caused a silent data loss in this scenario:

1. Partial cache hit: `unserializeTextResults()` returns anonymous class objects
2. Fresh DeepL translations are fetched for uncached texts: `TextResult` objects
3. Both are combined and stored as complete cache entry via `setCachedTranslation()`
4. `serializeTextResults()` converts `TextResult` to proper array, anonymous class to **null**
5. Next retrieval returns null for previously cached translations
6. `$v->text` on null triggers `str_replace(): Argument #2 must be array|string, null given`

The v2.4.1 fix added `if ($v === null) { continue; }` null-skips in the translation loops. This treats the **symptom** but does not prevent the silent data loss in the cache.

## Fix

Replace the anonymous class in `unserializeTextResults()` with real `TextResult` objects:

```php
$results[$index] = new TextResult(
    $data['text'],
    $data['detected_source_lang'] ?? '',
    $data['billed_characters'] ?? 0
);
```

## TDD verification

| Test | Without fix | With fix |
|------|-----------|---------|
| Single roundtrip preserves data | PASS | PASS |
| **Double roundtrip preserves data** | **FAIL** (null) | PASS |
| Null values preserved | PASS | PASS |
| **Unserialized results are TextResult instances** | **FAIL** (anonymous class) | PASS |

## Test plan

- [x] Unit test: single serialize/unserialize roundtrip preserves text, language, billed characters
- [x] Unit test: double roundtrip (the bug scenario) preserves all data
- [x] Unit test: null values in result array remain null
- [x] Unit test: unserialized results are `instanceof TextResult`

Fixes #94