### PR TITLE
Fix exclude check and missing eval key for slug fields

### DIFF
--- a/Build/UnitTests.xml
+++ b/Build/UnitTests.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
+    bootstrap="../.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
+    colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>../Tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/Classes/Utility/SlugUtility.php
+++ b/Classes/Utility/SlugUtility.php
@@ -45,12 +45,13 @@ class SlugUtility
      * @param string $field
      * @return string|null
      */
-    public static function generateSlug(array $record, string $tableName, string $field): ?string
+    public static function generateSlug(array $record, string $tableName, string $field, ?array $slugFields = null): ?string
     {
-        $slugFields = self::slugFields($tableName);
+        $slugFields ??= self::slugFields($tableName);
 
-        if (empty($slugFields) || !isset($slugFields[$field]))
+        if (empty($slugFields) || !isset($slugFields[$field]) || ($slugFields[$field]['exclude'] ?? false)) {
             return null;
+        }
 
         $fieldConfig = $slugFields[$field]['config'];
 
@@ -61,7 +62,7 @@ class SlugUtility
             $fieldConfig
         );
 
-        $evalInfo = GeneralUtility::trimExplode(',', $fieldConfig['eval'], true);
+        $evalInfo = GeneralUtility::trimExplode(',', $fieldConfig['eval'] ?? '', true);
         $state = RecordStateFactory::forName($tableName)->fromArray($record, $record['pid'], $record['uid']);
 
         // Generate slug

--- a/Classes/Utility/Translator.php
+++ b/Classes/Utility/Translator.php
@@ -797,7 +797,7 @@ class Translator implements LoggerAwareInterface
             $fieldsToUpdate = [];
 
             foreach (array_keys($slugFields) as $field) {
-                $slug = SlugUtility::generateSlug($record, $table, $field);
+                $slug = SlugUtility::generateSlug($record, $table, $field, $slugFields);
                 if ($slug === null) {
                     continue;
                 }

--- a/Tests/Unit/Utility/SlugUtilityTest.php
+++ b/Tests/Unit/Utility/SlugUtilityTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThieleUndKlose\Autotranslate\Tests\Unit\Utility;
+
+use PHPUnit\Framework\TestCase;
+use ThieleUndKlose\Autotranslate\Utility\SlugUtility;
+
+/**
+ * Unit tests for SlugUtility.
+ *
+ * Verifies that slug field detection and generation correctly handles
+ * the TCA 'exclude' flag and missing 'eval' configuration.
+ *
+ * @see https://github.com/thieleundklose/tk-typo3-autotranslate/issues/108
+ */
+final class SlugUtilityTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Reset TCA for each test
+        unset($GLOBALS['TCA']['test_table']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TCA']['test_table']);
+        parent::tearDown();
+    }
+
+    /**
+     * Verifies that slugFields() returns columns whose TCA type is 'slug'
+     * and ignores columns with other types.
+     */
+    public function testSlugFieldsReturnsOnlySlugTypeColumns(): void
+    {
+        $GLOBALS['TCA']['test_table']['columns'] = [
+            'title' => [
+                'config' => ['type' => 'input'],
+            ],
+            'slug' => [
+                'config' => ['type' => 'slug', 'generatorOptions' => ['fields' => ['title']]],
+            ],
+            'description' => [
+                'config' => ['type' => 'text'],
+            ],
+        ];
+
+        $result = SlugUtility::slugFields('test_table');
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('slug', $result);
+        self::assertArrayNotHasKey('title', $result);
+        self::assertArrayNotHasKey('description', $result);
+    }
+
+    /**
+     * Verifies that generateSlug() returns null when the slug field has
+     * 'exclude' => true in TCA. Fields marked as excluded should not have
+     * their slugs auto-generated during translation.
+     *
+     * This is the primary regression test for issue #108.
+     */
+    public function testGenerateSlugReturnsNullForExcludedField(): void
+    {
+        $GLOBALS['TCA']['test_table']['columns'] = [
+            'slug' => [
+                'exclude' => true,
+                'config' => [
+                    'type' => 'slug',
+                    'generatorOptions' => ['fields' => ['title']],
+                ],
+            ],
+        ];
+
+        $record = ['uid' => 1, 'pid' => 1, 'title' => 'Test Title', 'slug' => ''];
+        $result = SlugUtility::generateSlug($record, 'test_table', 'slug');
+
+        self::assertNull($result, 'generateSlug() must return null for excluded slug fields');
+    }
+
+    /**
+     * Verifies that generateSlug() returns null when the requested field
+     * does not exist in the TCA slug fields.
+     */
+    public function testGenerateSlugReturnsNullForNonExistentField(): void
+    {
+        $GLOBALS['TCA']['test_table']['columns'] = [
+            'slug' => [
+                'config' => ['type' => 'slug', 'generatorOptions' => ['fields' => ['title']]],
+            ],
+        ];
+
+        $record = ['uid' => 1, 'pid' => 1, 'title' => 'Test'];
+        $result = SlugUtility::generateSlug($record, 'test_table', 'nonexistent_field');
+
+        self::assertNull($result);
+    }
+
+    /**
+     * Verifies that generateSlug() returns null when the table has no
+     * slug fields at all.
+     */
+    public function testGenerateSlugReturnsNullForTableWithoutSlugFields(): void
+    {
+        $GLOBALS['TCA']['test_table']['columns'] = [
+            'title' => [
+                'config' => ['type' => 'input'],
+            ],
+        ];
+
+        $record = ['uid' => 1, 'pid' => 1, 'title' => 'Test'];
+        $result = SlugUtility::generateSlug($record, 'test_table', 'slug');
+
+        self::assertNull($result);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">= 7.4 < 8.5"
     },
     "require-dev": {
-        "typo3/testing-framework": "^6.8"
+        "typo3/testing-framework": "^6.8 || ^7.0 || ^8.2 || ^9.0"
     },
     "autoload": {
         "psr-4": {
@@ -34,11 +34,21 @@
     },
     "config": {
         "vendor-dir": ".Build/vendor",
-        "bin-dir": ".Build/bin"
+        "bin-dir": ".Build/bin",
+        "allow-plugins": {
+            "typo3/cms-composer-installers": true,
+            "typo3/class-alias-loader": true
+        }
     },
     "scripts": {
         "post-autoload-dump": [
             "TYPO3\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare"
+        ],
+        "ci:test:php:unit": [
+            "phpunit --configuration Build/UnitTests.xml"
+        ],
+        "ci:test": [
+            "@ci:test:php:unit"
         ]
     },
     "extra": {


### PR DESCRIPTION
## Summary

- **Check TCA `exclude` flag**: `generateSlug()` now returns `null` for slug fields with `'exclude' => true`, preventing auto-generation of excluded slugs
- **Fix PHP Warning**: Handle missing `eval` key in slug field config (`$fieldConfig['eval'] ?? ''`) to prevent `Undefined array key "eval"` warning
- **Performance**: Accept optional pre-computed `$slugFields` parameter to avoid redundant `slugFields()` calls in `Translator::generateSlugs()` loop (was O(n+1), now O(1))

## Operator precedence fix

The POC in #108 has an operator precedence issue:
```php
// POC (wrong): ?? has lower precedence than ||
$slugFields[$field]['exclude'] ?? false

// Fix: parentheses ensure correct evaluation
($slugFields[$field]['exclude'] ?? false)
```

## Test plan

- [x] Unit test: `testGenerateSlugReturnsNullForExcludedField` — verifies excluded slug fields return null
- [x] Unit test: `testSlugFieldsReturnsOnlySlugTypeColumns` — verifies slug field detection
- [x] Unit test: `testGenerateSlugReturnsNullForNonExistentField` — verifies non-existent fields return null
- [x] Unit test: `testGenerateSlugReturnsNullForTableWithoutSlugFields` — verifies tables without slugs return null
- [x] TDD: test failed before fix, passes after fix
- [x] All existing tests still pass

Fixes #108