### PR TITLE
Correctly handle int values in isRichtextField check

### DIFF
--- a/Classes/Utility/Translator.php
+++ b/Classes/Utility/Translator.php
@@ -623,7 +623,7 @@ class Translator implements LoggerAwareInterface
         }
 
         // check if the field is a richtext field
-        return isset($fieldConfig['enableRichtext']) && $fieldConfig['enableRichtext'] === true;
+        return isset($fieldConfig['enableRichtext']) && $fieldConfig['enableRichtext'];
     }
     /**
      * Replaces placeholders in the HTML with the translated attribute values.


### PR DESCRIPTION
The TCA field enableRichtext can also have a int value and the strict comparison would not enable the richtext flag in this case and yield translations with broken html tags.

Probably releated to #84 