### PR TITLE
Fix translated reference visibility

### DIFF
--- a/Classes/Utility/Translator.php
+++ b/Classes/Utility/Translator.php
@@ -218,11 +218,14 @@ class Translator implements LoggerAwareInterface
                                     $dataHandler->start([], []);
                                     $translatedReferenceUid = $dataHandler->localize($referenceTable, $referenceUid, $languageId);
 
+                                    $hidden = Records::getRecord($referenceTable, $referenceUid, 'hidden') ?? 0;
+
                                     Records::updateRecord(
                                         $referenceTable,
                                         $translatedReferenceUid,
                                         [
                                             $foreignField => $localizedContents[$languageId][$recordUid],
+                                            'hidden' => $hidden,
                                         ]
                                     );
 


### PR DESCRIPTION
## Summary
Preserve the original `hidden` state when autotranslate creates localized reference records.

## Problem
When a new localized reference is created, the translated reference currently only gets the updated foreign relation. The original visibility is not copied, so hidden source references can become visible in the translation.

## Fix
Read `hidden` from the original reference record and write it to the localized reference during `Records::updateRecord(...)`.

## Result
Translated references keep the same visibility as the original reference record.
