### PR TITLE
Skip DeepL round-trips when DataHandler update changed no translatable field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+/.Build/
+/composer.lock
+/Build/.phpunit.result.cache

--- a/Build/UnitTests.xml
+++ b/Build/UnitTests.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
+    bootstrap="../.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php"
+    colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit Tests">
+            <directory>../Tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -80,11 +80,24 @@ class DataHandler implements SingletonInterface
             return;
         }
 
+        // Forward the list of datamap keys so Translator::translate() can
+        // skip DeepL round-trips for the main record when only status fields
+        // (e.g. "hidden" flipped by a cron) have changed. New records pass
+        // null, which keeps the previous "translate everything" behaviour.
+        $changedFields = TranslationHelper::extractChangedFieldsFromDatamap($status, $fields);
+
         $translator = GeneralUtility::makeInstance(Translator::class, $pageId);
 
         try {
             if (in_array($table, TranslationHelper::tablesToTranslate())) {
-                $translator->translate($table, (int)$recordUid, $parentObject);
+                $translator->translate(
+                    $table,
+                    (int)$recordUid,
+                    $parentObject,
+                    null,
+                    Translator::TRANSLATE_MODE_BOTH,
+                    $changedFields
+                );
             }
         } catch (\Exception $e) {
             FlashMessageUtility::addMessage(

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -33,7 +33,7 @@ class DataHandler implements SingletonInterface
     private bool $suspended = false;
 
     /**
-     * @var array<string, array<int, int>>
+     * @var array<string, array<int, array{pageId: int, changedFields: string[]|null}>>
      */
     private array $translationQueue = [];
 
@@ -114,7 +114,16 @@ class DataHandler implements SingletonInterface
             return;
         }
 
-        $this->translationQueue[$table][(int)$recordUid] = (int)$pageId;
+        // Forward the list of datamap keys so Translator::translate() can
+        // skip DeepL round-trips for the main record when only status fields
+        // (e.g. "hidden" flipped by a cron) have changed. New records pass
+        // null, which keeps the previous "translate everything" behaviour.
+        $changedFields = TranslationHelper::extractChangedFieldsFromDatamap($status, $fields);
+
+        $this->translationQueue[$table][(int)$recordUid] = [
+            'pageId' => (int)$pageId,
+            'changedFields' => $changedFields,
+        ];
 
         return;
     }
@@ -133,7 +142,10 @@ class DataHandler implements SingletonInterface
                 continue;
             }
 
-            foreach ($records as $recordUid => $pageId) {
+            foreach ($records as $recordUid => $queueItem) {
+                $pageId = (int)($queueItem['pageId'] ?? 0);
+                $changedFields = $queueItem['changedFields'] ?? null;
+
                 $record = Records::getRecord($table, (int)$recordUid);
                 if ($record === null) {
                     continue;
@@ -152,8 +164,15 @@ class DataHandler implements SingletonInterface
                 $translator = GeneralUtility::makeInstance(Translator::class, (int)$pageId);
 
                 try {
-                    self::runWithSuspendedHook(static function () use ($translator, $table, $recordUid, $parentObject, $targetLanguages): void {
-                        $translator->translate($table, (int)$recordUid, $parentObject, implode(',', $targetLanguages));
+                    self::runWithSuspendedHook(static function () use ($translator, $table, $recordUid, $parentObject, $targetLanguages, $changedFields): void {
+                        $translator->translate(
+                            $table,
+                            (int)$recordUid,
+                            $parentObject,
+                            implode(',', $targetLanguages),
+                            Translator::TRANSLATE_MODE_BOTH,
+                            $changedFields
+                        );
                     });
                 } catch (\Exception $e) {
                     FlashMessageUtility::addMessage(

--- a/Classes/Utility/TranslationHelper.php
+++ b/Classes/Utility/TranslationHelper.php
@@ -50,6 +50,58 @@ class TranslationHelper
     }
 
     /**
+     * Derive the list of changed fields from a DataHandler datamap operation.
+     *
+     * New records save a pristine state with every column provided, so the
+     * caller should not reduce the translation scope, null is returned to
+     * signal "translate everything". Updates return the datamap keys, which
+     * are the exact fields that were submitted for this save; downstream
+     * code intersects them with the configured translatable columns to
+     * decide whether a translation is necessary.
+     *
+     * @param string $status DataHandler hook status ('new' or 'update').
+     * @param array $datamap Datamap entry for the current record (fieldArray).
+     * @return string[]|null Null for new records, otherwise the changed field names.
+     */
+    public static function extractChangedFieldsFromDatamap(string $status, array $datamap): ?array
+    {
+        if ($status === 'new') {
+            return null;
+        }
+
+        return array_keys($datamap);
+    }
+
+    /**
+     * Narrow the configured translatable columns to the ones that actually
+     * have to be translated in the current DataHandler operation.
+     *
+     * New records supply a null changed-fields list, which means the whole
+     * configured set is returned (translate everything, as before).
+     * Updates supply the keys of the datamap entry: the result is the
+     * intersection with the configured columns, so a status-only update
+     * (e.g. hidden/starttime) yields an empty list and the caller can
+     * skip the translation call entirely.
+     *
+     * The result preserves the order of $translatableColumns so downstream
+     * processing stays deterministic.
+     *
+     * @param string[] $translatableColumns Columns configured as translatable.
+     * @param string[]|null $changedFields Datamap field names, or null for new records.
+     * @return string[] Empty array = nothing to translate.
+     */
+    public static function filterChangedTranslatableColumns(
+        array $translatableColumns,
+        ?array $changedFields
+    ): array {
+        if ($changedFields === null) {
+            return array_values($translatableColumns);
+        }
+
+        return array_values(array_intersect($translatableColumns, $changedFields));
+    }
+
+    /**
      * Collect translateable fields from TCA.
      *
      * @param string $table

--- a/Classes/Utility/TranslationHelper.php
+++ b/Classes/Utility/TranslationHelper.php
@@ -50,6 +50,58 @@ class TranslationHelper
     }
 
     /**
+     * Derive the list of changed fields from a DataHandler datamap operation.
+     *
+     * New records save a pristine state with every column provided, so the
+     * caller should not reduce the translation scope — null is returned to
+     * signal "translate everything". Updates return the datamap keys, which
+     * are the exact fields that were submitted for this save; downstream
+     * code intersects them with the configured translatable columns to
+     * decide whether a translation is necessary.
+     *
+     * @param string $status DataHandler hook status ('new' or 'update').
+     * @param array $datamap Datamap entry for the current record (fieldArray).
+     * @return string[]|null Null for new records, otherwise the changed field names.
+     */
+    public static function extractChangedFieldsFromDatamap(string $status, array $datamap): ?array
+    {
+        if ($status === 'new') {
+            return null;
+        }
+
+        return array_keys($datamap);
+    }
+
+    /**
+     * Narrow the configured translatable columns to the ones that actually
+     * have to be translated in the current DataHandler operation.
+     *
+     * New records supply a null changed-fields list, which means the whole
+     * configured set is returned (translate everything, as before).
+     * Updates supply the keys of the datamap entry: the result is the
+     * intersection with the configured columns, so a status-only update
+     * (e.g. hidden/starttime) yields an empty list and the caller can
+     * skip the translation call entirely.
+     *
+     * The result preserves the order of $translatableColumns so downstream
+     * processing stays deterministic.
+     *
+     * @param string[] $translatableColumns Columns configured as translatable.
+     * @param string[]|null $changedFields Datamap field names, or null for new records.
+     * @return string[] Empty array = nothing to translate.
+     */
+    public static function filterChangedTranslatableColumns(
+        array $translatableColumns,
+        ?array $changedFields
+    ): array {
+        if ($changedFields === null) {
+            return array_values($translatableColumns);
+        }
+
+        return array_values(array_intersect($translatableColumns, $changedFields));
+    }
+
+    /**
      * Collect translateable fields from TCA.
      *
      * @param string $table

--- a/Classes/Utility/Translator.php
+++ b/Classes/Utility/Translator.php
@@ -68,10 +68,15 @@ class Translator implements LoggerAwareInterface
      * @param DataHandler|null $parentObject
      * @param string|null $languagesToTranslate
      * @param string $translateMode
+     * @param string[]|null $changedFields Datamap field names for the current save, or null for
+     *                                     new records. When set, the main-record translation of an
+     *                                     existing localized record is narrowed to the intersection
+     *                                     with the configured translatable columns; a newly created
+     *                                     localization is always translated in full.
      * @return void
      * @throws \Doctrine\DBAL\Driver\Exception
      */
-    public function translate(string $table, int $recordUid, ?DataHandler $parentObject = null, ?string $languagesToTranslate = null, string $translateMode = self::TRANSLATE_MODE_BOTH): void
+    public function translate(string $table, int $recordUid, ?DataHandler $parentObject = null, ?string $languagesToTranslate = null, string $translateMode = self::TRANSLATE_MODE_BOTH, ?array $changedFields = null): void
     {
 
         $deeplApiKeyDetails = DeeplApiHelper::checkApiKey($this->apiKey);
@@ -258,8 +263,18 @@ class Translator implements LoggerAwareInterface
                 $translateMode
             );
 
+            // A freshly created localization must be translated in full even
+            // when the source save changed no text field (e.g. an editor only
+            // added a target language; the TYPO3 core prunes unchanged fields
+            // from the datamap). An existing translation is narrowed to the
+            // columns that actually changed, so a status-only update skips
+            // DeepL entirely. Reference tables keep the full set above.
+            $mainRecordColumns = $existingTranslation
+                ? TranslationHelper::filterChangedTranslatableColumns($columns, $changedFields)
+                : $columns;
+
             // Translate properties with given service
-            $translatedColumns = $this->translateRecordProperties($record, (int)$languageId, $columns, $table, $localizedUid);
+            $translatedColumns = $this->translateRecordProperties($record, (int)$languageId, $mainRecordColumns, $table, $localizedUid);
 
             if (count($translatedColumns) > 0) {
                 Records::updateRecord($table, $localizedUid, $translatedColumns);

--- a/Classes/Utility/Translator.php
+++ b/Classes/Utility/Translator.php
@@ -65,10 +65,16 @@ class Translator implements LoggerAwareInterface
      * @param DataHandler|null $parentObject
      * @param string|null $languagesToTranslate
      * @param string $translateMode
+     * @param string[]|null $changedFields Datamap keys from the DataHandler save, or null for
+     *                                     new records. When supplied, the translation of the
+     *                                     main record is restricted to the intersection with
+     *                                     the configured translatable columns. Reference tables
+     *                                     keep their previous behaviour so editors see file
+     *                                     translations propagate on every save.
      * @return void
      * @throws \Doctrine\DBAL\Driver\Exception
      */
-    public function translate(string $table, int $recordUid, ?DataHandler $parentObject = null, ?string $languagesToTranslate = null, string $translateMode = self::TRANSLATE_MODE_BOTH): void
+    public function translate(string $table, int $recordUid, ?DataHandler $parentObject = null, ?string $languagesToTranslate = null, string $translateMode = self::TRANSLATE_MODE_BOTH, ?array $changedFields = null): void
     {
 
         $deeplApiKeyDetails = DeeplApiHelper::checkApiKey($this->apiKey);
@@ -109,6 +115,10 @@ class Translator implements LoggerAwareInterface
         if ($columns === null) {
             return;
         }
+
+        // narrow the main-record translation to the columns that actually
+        // changed; reference handling below keeps the full configured set
+        $mainRecordColumns = TranslationHelper::filterChangedTranslatableColumns($columns, $changedFields);
 
         // set target languages by record if null is given
         if (is_null($languagesToTranslate)) {
@@ -249,7 +259,7 @@ class Translator implements LoggerAwareInterface
 
 
             // Translate properties with given service
-            $translatedColumns = $this->translateRecordProperties($record, (int)$languageId, $columns, $table, $localizedUid);
+            $translatedColumns = $this->translateRecordProperties($record, (int)$languageId, $mainRecordColumns, $table, $localizedUid);
 
             if (count($translatedColumns) > 0) {
                 Records::updateRecord($table, $localizedUid, $translatedColumns);

--- a/Tests/Unit/Utility/TranslationHelperTest.php
+++ b/Tests/Unit/Utility/TranslationHelperTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThieleUndKlose\Autotranslate\Tests\Unit\Utility;
+
+use PHPUnit\Framework\TestCase;
+use ThieleUndKlose\Autotranslate\Utility\TranslationHelper;
+
+/**
+ * Unit tests for TranslationHelper::filterChangedTranslatableColumns().
+ *
+ * The helper decides which translatable columns have to be handed over to
+ * the translator based on the DataHandler datamap of the current save.
+ */
+final class TranslationHelperTest extends TestCase
+{
+    /**
+     * A 'new' datamap status means the record is being created. The full
+     * set of translatable columns must be translated on first save, so
+     * the helper returns null to signal "no restriction".
+     */
+    public function testExtractChangedFieldsReturnsNullForNewRecords(): void
+    {
+        $result = TranslationHelper::extractChangedFieldsFromDatamap(
+            'new',
+            ['title' => 'Hello', 'hidden' => 0]
+        );
+
+        self::assertNull($result);
+    }
+
+    /**
+     * On updates the helper returns the datamap keys so the caller can
+     * intersect them with the configured translatable columns.
+     */
+    public function testExtractChangedFieldsReturnsDatamapKeysForUpdates(): void
+    {
+        $result = TranslationHelper::extractChangedFieldsFromDatamap(
+            'update',
+            ['title' => 'World', 'hidden' => 1]
+        );
+
+        self::assertSame(['title', 'hidden'], $result);
+    }
+
+    /**
+     * An update with an empty datamap yields an empty list of changed
+     * fields, which downstream is treated as "nothing translatable
+     * changed" — no DeepL round-trip.
+     */
+    public function testExtractChangedFieldsReturnsEmptyArrayForUpdateWithoutFields(): void
+    {
+        $result = TranslationHelper::extractChangedFieldsFromDatamap('update', []);
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * A null changed-fields list represents a new record: the full set of
+     * configured translatable columns must be returned so everything gets
+     * translated on first save (existing behaviour).
+     */
+    public function testReturnsAllConfiguredColumnsWhenChangedFieldsIsNull(): void
+    {
+        $result = TranslationHelper::filterChangedTranslatableColumns(
+            ['title', 'description'],
+            null
+        );
+
+        self::assertSame(['title', 'description'], $result);
+    }
+
+    /**
+     * An update that only touches non-translatable status fields
+     * (e.g. hidden via a cron job) must yield an empty result so the
+     * caller can skip the translation round-trip entirely.
+     */
+    public function testReturnsEmptyWhenOnlyNonTranslatableFieldsChanged(): void
+    {
+        $result = TranslationHelper::filterChangedTranslatableColumns(
+            ['title', 'description'],
+            ['hidden', 'starttime', 'tstamp']
+        );
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * An update touching both translatable and non-translatable fields
+     * must return only the translatable subset.
+     */
+    public function testReturnsOnlyChangedTranslatableColumns(): void
+    {
+        $result = TranslationHelper::filterChangedTranslatableColumns(
+            ['title', 'description', 'teaser'],
+            ['title', 'hidden', 'tstamp']
+        );
+
+        self::assertSame(['title'], $result);
+    }
+
+    /**
+     * An explicit empty changed-fields list (as opposed to null) means
+     * an update with no recorded changes — still nothing to translate.
+     */
+    public function testReturnsEmptyWhenChangedFieldsIsEmpty(): void
+    {
+        $result = TranslationHelper::filterChangedTranslatableColumns(
+            ['title', 'description'],
+            []
+        );
+
+        self::assertSame([], $result);
+    }
+
+    /**
+     * Without configured translatable columns, every call returns an
+     * empty list — there is nothing that could be translated.
+     */
+    public function testReturnsEmptyWhenNoTranslatableColumnsConfigured(): void
+    {
+        self::assertSame(
+            [],
+            TranslationHelper::filterChangedTranslatableColumns([], ['title', 'hidden'])
+        );
+        self::assertSame(
+            [],
+            TranslationHelper::filterChangedTranslatableColumns([], null)
+        );
+    }
+
+    /**
+     * The result order follows the configured translatable columns, not
+     * the order of the changed-fields input, so downstream processing
+     * (cache keys, DeepL batch order) stays stable across call sites.
+     */
+    public function testResultOrderFollowsConfiguredColumns(): void
+    {
+        $result = TranslationHelper::filterChangedTranslatableColumns(
+            ['title', 'teaser', 'description'],
+            ['description', 'title']
+        );
+
+        self::assertSame(['title', 'description'], $result);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">= 7.4 < 8.5"
     },
     "require-dev": {
-        "typo3/testing-framework": "^6.8"
+        "typo3/testing-framework": "^6.8 || ^7.0 || ^8.2 || ^9.0"
     },
     "autoload": {
         "psr-4": {
@@ -34,11 +34,21 @@
     },
     "config": {
         "vendor-dir": ".Build/vendor",
-        "bin-dir": ".Build/bin"
+        "bin-dir": ".Build/bin",
+        "allow-plugins": {
+            "typo3/cms-composer-installers": true,
+            "typo3/class-alias-loader": true
+        }
     },
     "scripts": {
         "post-autoload-dump": [
             "TYPO3\\TestingFramework\\Composer\\ExtensionTestEnvironment::prepare"
+        ],
+        "ci:test:php:unit": [
+            "phpunit --configuration Build/UnitTests.xml"
+        ],
+        "ci:test": [
+            "@ci:test:php:unit"
         ]
     },
     "extra": {


### PR DESCRIPTION
## What

Skip DeepL round-trips for a record save that changed no translatable text field. A cron job (or any edit) that only flips status fields such as `hidden`, `starttime` or `endtime` no longer sends the main record's text columns to DeepL.

## How

- `TranslationHelper::extractChangedFieldsFromDatamap()` turns the DataHandler `status`/datamap pair into either `null` (new record → translate everything, as before) or the list of changed datamap keys for updates.
- `TranslationHelper::filterChangedTranslatableColumns()` intersects the configured translatable columns with the changed fields, preserving the configured column order.
- The DataHandler hook carries the changed-field list through the deferred translation queue and forwards it via a new `$changedFields` argument on `Translator::translate()`.
- `Translator::translate()` narrows the **main-record** translation to the intersected columns **for an existing localization**. A **newly created localization is always translated in full**, so adding a target language to a record without touching its text still produces a complete translation (the TYPO3 core prunes unchanged fields from the datamap before the hook fires). **Reference tables keep their previous behaviour** so file translations still propagate on every save.

## Notes

- Rebased onto the v2.6.0 deferred translation queue (`processDatamap_afterAllOperations`); the changed-field list is stored per record in the queue and forwarded when the queue is processed.
- All other `translate()` callers (batch, AJAX) omit the new argument and keep the full-translation behaviour.

## Tests

`TranslationHelperTest` covers every branch of both helpers (new vs update, empty/partial intersection, order preservation). Adds `Build/UnitTests.xml` and a `ci:test:php:unit` script.