### PR TITLE
Defer DeepL checkApiKey() until a translation is actually attempted

### DIFF
--- a/Classes/Utility/Translator.php
+++ b/Classes/Utility/Translator.php
@@ -48,6 +48,13 @@ class Translator implements LoggerAwareInterface
     protected $glossaryService = null;
 
     /**
+     * Cached DeepL checkApiKey() result for this Translator instance.
+     * Populated on the first actual DeepL invocation and reused for all
+     * subsequent ones so cron runs only hit the usage endpoint once.
+     */
+    private ?array $deeplApiKeyDetails = null;
+
+    /**
      * object constructor
      *
      * @param int $pageId
@@ -73,31 +80,6 @@ class Translator implements LoggerAwareInterface
      */
     public function translate(string $table, int $recordUid, ?DataHandler $parentObject = null, ?string $languagesToTranslate = null, string $translateMode = self::TRANSLATE_MODE_BOTH): void
     {
-
-        $deeplApiKeyDetails = DeeplApiHelper::checkApiKey($this->apiKey);
-        if ($deeplApiKeyDetails['error']){
-            LogUtility::log($this->logger, 'DeepL API Key is not valid: {error}', [
-                'error' => $deeplApiKeyDetails['error']
-            ]);
-            throw new \RuntimeException('DeepL API Key is not valid: ' . $deeplApiKeyDetails['error']);
-        }
-        if (!empty($deeplApiKeyDetails['warning'])) {
-            LogUtility::log($this->logger, 'DeepL API warning: {warning}', [
-                'warning' => $deeplApiKeyDetails['warning']
-            ], LogUtility::MESSAGE_WARNING);
-        }
-        if (!$deeplApiKeyDetails['isValid']) {
-            LogUtility::log($this->logger, 'DeepL API Key is not valid: {error}', [
-                'error' => 'No API Key given.'
-            ]);
-            throw new \RuntimeException('DeepL API Key is not valid: No API Key given.');
-        }
-        if ($deeplApiKeyDetails['charactersLeft'] !== null && $deeplApiKeyDetails['charactersLeft'] <= 0) {
-            LogUtility::log($this->logger, 'DeepL API Key has no characters left: {charactersLeft}', [
-                'charactersLeft' => $deeplApiKeyDetails['charactersLeft']
-            ]);
-            throw new \RuntimeException('DeepL API Key has no characters left: ' . $deeplApiKeyDetails['charactersLeft']);
-        }
 
         $record = Records::getRecord($table, $recordUid);
 
@@ -493,6 +475,13 @@ class Translator implements LoggerAwareInterface
         // create translation array from source record by keys from fielmap
         $translatedColumns = [];
 
+        // Validate the DeepL API key before entering the try/catch below so
+        // a genuinely broken key surfaces as a RuntimeException to the hook
+        // (flash message) instead of being swallowed as a translation error.
+        if (count($columns) > 0) {
+            $this->ensureValidApiKey();
+        }
+
         try {
             // prepare translated record with source record
             // create translation array from source record by keys from fielmap
@@ -639,6 +628,43 @@ class Translator implements LoggerAwareInterface
             ], LogUtility::MESSAGE_ERROR);
 
             return '{}';
+        }
+    }
+
+    /**
+     * Validate the configured DeepL API key exactly once per Translator
+     * instance and re-use the cached usage details on every subsequent
+     * DeepL invocation. Throws RuntimeException if the key is unusable.
+     */
+    private function ensureValidApiKey(): void
+    {
+        if ($this->deeplApiKeyDetails === null) {
+            $this->deeplApiKeyDetails = DeeplApiHelper::checkApiKey($this->apiKey);
+        }
+
+        $details = $this->deeplApiKeyDetails;
+        if ($details['error']) {
+            LogUtility::log($this->logger, 'DeepL API Key is not valid: {error}', [
+                'error' => $details['error']
+            ]);
+            throw new \RuntimeException('DeepL API Key is not valid: ' . $details['error']);
+        }
+        if (!empty($details['warning'])) {
+            LogUtility::log($this->logger, 'DeepL API warning: {warning}', [
+                'warning' => $details['warning']
+            ], LogUtility::MESSAGE_WARNING);
+        }
+        if (!$details['isValid']) {
+            LogUtility::log($this->logger, 'DeepL API Key is not valid: {error}', [
+                'error' => 'No API Key given.'
+            ]);
+            throw new \RuntimeException('DeepL API Key is not valid: No API Key given.');
+        }
+        if ($details['charactersLeft'] !== null && $details['charactersLeft'] <= 0) {
+            LogUtility::log($this->logger, 'DeepL API Key has no characters left: {charactersLeft}', [
+                'charactersLeft' => $details['charactersLeft']
+            ]);
+            throw new \RuntimeException('DeepL API Key has no characters left: ' . $details['charactersLeft']);
         }
     }
 

--- a/Classes/Utility/Translator.php
+++ b/Classes/Utility/Translator.php
@@ -45,6 +45,13 @@ class Translator implements LoggerAwareInterface
     protected $glossaryService = null;
 
     /**
+     * Cached DeepL checkApiKey() result for this Translator instance.
+     * Populated on the first actual DeepL invocation and reused for all
+     * subsequent ones so cron runs only hit the usage endpoint once.
+     */
+    private ?array $deeplApiKeyDetails = null;
+
+    /**
      * object constructor
      *
      * @param int $pageId
@@ -70,27 +77,6 @@ class Translator implements LoggerAwareInterface
      */
     public function translate(string $table, int $recordUid, ?DataHandler $parentObject = null, ?string $languagesToTranslate = null, string $translateMode = self::TRANSLATE_MODE_BOTH): void
     {
-
-        $deeplApiKeyDetails = DeeplApiHelper::checkApiKey($this->apiKey);
-        if ($deeplApiKeyDetails['error']){
-            LogUtility::log($this->logger, 'DeepL API Key is not valid: {error}', [
-                'error' => $deeplApiKeyDetails['error']
-            ]);
-            throw new \RuntimeException('DeepL API Key is not valid: ' . $deeplApiKeyDetails['error']);
-        }
-        if (!$deeplApiKeyDetails['isValid']) {
-            LogUtility::log($this->logger, 'DeepL API Key is not valid: {error}', [
-                'error' => 'No API Key given.'
-            ]);
-            throw new \RuntimeException('DeepL API Key is not valid: No API Key given.');
-        }
-        if ($deeplApiKeyDetails['charactersLeft'] <= 0) {
-            LogUtility::log($this->logger, 'DeepL API Key has no characters left: {charactersLeft}', [
-                'charactersLeft' => $deeplApiKeyDetails['charactersLeft']
-            ]);
-            throw new \RuntimeException('DeepL API Key has no characters left: ' . $deeplApiKeyDetails['charactersLeft']);
-        }
-
         $record = Records::getRecord($table, $recordUid);
 
         // exit if record is localized one
@@ -281,6 +267,13 @@ class Translator implements LoggerAwareInterface
         // create translation array from source record by keys from fielmap
         $translatedColumns = [];
 
+        // Validate the DeepL API key before entering the try/catch below so
+        // a genuinely broken key surfaces as a RuntimeException to the hook
+        // (flash message) instead of being swallowed as a translation error.
+        if (count($columns) > 0) {
+            $this->ensureValidApiKey();
+        }
+
         try {
             // prepare translated record with source record
             // create translation array from source record by keys from fielmap
@@ -427,6 +420,38 @@ class Translator implements LoggerAwareInterface
             ], LogUtility::MESSAGE_ERROR);
 
             return '{}';
+        }
+    }
+
+    /**
+     * Validate the configured DeepL API key exactly once per Translator
+     * instance and re-use the cached usage details on every subsequent
+     * DeepL invocation. Throws RuntimeException if the key is unusable.
+     */
+    private function ensureValidApiKey(): void
+    {
+        if ($this->deeplApiKeyDetails === null) {
+            $this->deeplApiKeyDetails = DeeplApiHelper::checkApiKey($this->apiKey);
+        }
+
+        $details = $this->deeplApiKeyDetails;
+        if ($details['error']) {
+            LogUtility::log($this->logger, 'DeepL API Key is not valid: {error}', [
+                'error' => $details['error']
+            ]);
+            throw new \RuntimeException('DeepL API Key is not valid: ' . $details['error']);
+        }
+        if (!$details['isValid']) {
+            LogUtility::log($this->logger, 'DeepL API Key is not valid: {error}', [
+                'error' => 'No API Key given.'
+            ]);
+            throw new \RuntimeException('DeepL API Key is not valid: No API Key given.');
+        }
+        if ($details['charactersLeft'] <= 0) {
+            LogUtility::log($this->logger, 'DeepL API Key has no characters left: {charactersLeft}', [
+                'charactersLeft' => $details['charactersLeft']
+            ]);
+            throw new \RuntimeException('DeepL API Key has no characters left: ' . $details['charactersLeft']);
         }
     }
 


### PR DESCRIPTION
## What

Defer the DeepL `checkApiKey()` usage call until a translation is actually attempted, so record saves that never reach DeepL no longer trigger one usage HTTP round-trip each.

## Why

The DataHandler hook instantiates a fresh `Translator` per queued record. Until now `translate()` queried the DeepL usage endpoint at its top, even for records that never reach DeepL: excluded records, records whose configured translatable columns are all empty, or (combined with the changed-field filter from #122) records that only had status fields changed. A cron run over hundreds of records therefore burned one usage round-trip per record.

## How

- Cache the `checkApiKey()` result on a private property and populate it lazily from a new `ensureValidApiKey()`.
- Call `ensureValidApiKey()` at the top of `translateRecordProperties()`, outside the `try/catch`, gated on `count($columns) > 0`. Placing it before the `try/catch` keeps a `RuntimeException` from an invalid/exhausted key propagating up so the DataHandler hook still surfaces it as a flash message instead of swallowing it as a translation error.

## Notes

Rebased onto v2.6.0. Validation logic (error/warning/isValid/charactersLeft) is unchanged, only its call site and caching.