### PR TITLE
Fix sys_file_reference ext_tables.sql syntax

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -29,8 +29,8 @@ CREATE TABLE tx_news_domain_model_news (
 # Table structure for extending table 'sys_file_reference'
 #
 CREATE TABLE sys_file_reference (
-    autotranslate_last int(11) DEFAULT '0' NOT NULL
     autotranslate_exclude tinyint(4) DEFAULT '0' NOT NULL,
+    autotranslate_last int(11) DEFAULT '0' NOT NULL
 );
 
 #


### PR DESCRIPTION
## Problem

The current `ext_tables.sql` definition for `sys_file_reference` is invalid:

```sql
CREATE TABLE sys_file_reference (
    autotranslate_last int(11) DEFAULT '0' NOT NULL
    autotranslate_exclude tinyint(4) DEFAULT '0' NOT NULL,
);
```

The comma between `autotranslate_last` and `autotranslate_exclude` is missing, and the trailing comma after `autotranslate_exclude` produces an extra empty column position before the closing paren. TYPO3's schema parser rejects this with:

```
[SQL Error] line 0, col 82: Error: Expected NOT, NULL, DEFAULT,
AUTO_INCREMENT, UNIQUE, PRIMARY, COMMENT, COLUMN_FORMAT, STORAGE,
REFERENCES, CHARACTER SET or COLLATE, got 'autotranslate_exclude'
in statement: CREATE TABLE sys_file_reference (...)
```

This blocks `vendor/bin/typo3 upgrade:list`, `upgrade:run` and `database:updateschema` on any TYPO3 v14 install that uses the 3.x branch.

## Fix

Place the comma correctly and reorder the columns to match the convention used by `pages`, `tt_content` and `tx_news_domain_model_news` in the same file (`autotranslate_exclude` first, `autotranslate_last` last).

```sql
CREATE TABLE sys_file_reference (
    autotranslate_exclude tinyint(4) DEFAULT '0' NOT NULL,
    autotranslate_last int(11) DEFAULT '0' NOT NULL
);
```

## Verification

After applying, `typo3 upgrade:list` runs without the StatementException and `database:updateschema` adds the two columns correctly.