### PR TITLE
[3.x] Defer DeepL checkApiKey() until a translation is actually attempted

### DIFF
--- a/Classes/Utility/Translator.php
+++ b/Classes/Utility/Translator.php
@@ -29,6 +29,7 @@ final class Translator implements LoggerAwareInterface
     private readonly ?string $apiKey;
     private readonly array $siteLanguages;
     private readonly GlossaryService $glossaryService;
+    private ?array $deeplApiKeyDetails = null;
 
     public function __construct(private readonly int $pageId)
     {
@@ -49,26 +50,6 @@ final class Translator implements LoggerAwareInterface
         ?string $languagesToTranslate = null,
         string $translateMode = self::TRANSLATE_MODE_BOTH
     ): void {
-        $deeplApiKeyDetails = DeeplApiHelper::checkApiKey($this->apiKey);
-        if ($deeplApiKeyDetails['error']) {
-            LogUtility::log($this->logger, 'DeepL API Key is not valid: {error}', [
-                'error' => $deeplApiKeyDetails['error'],
-            ]);
-            throw new \RuntimeException('DeepL API Key is not valid: ' . $deeplApiKeyDetails['error']);
-        }
-        if (!$deeplApiKeyDetails['isValid']) {
-            LogUtility::log($this->logger, 'DeepL API Key is not valid: {error}', [
-                'error' => 'No API Key given.',
-            ]);
-            throw new \RuntimeException('DeepL API Key is not valid: No API Key given.');
-        }
-        if ($deeplApiKeyDetails['charactersLeft'] <= 0) {
-            LogUtility::log($this->logger, 'DeepL API Key has no characters left: {charactersLeft}', [
-                'charactersLeft' => $deeplApiKeyDetails['charactersLeft'],
-            ]);
-            throw new \RuntimeException('DeepL API Key has no characters left: ' . $deeplApiKeyDetails['charactersLeft']);
-        }
-
         $record = Records::getRecord($table, $recordUid);
 
         if ($record === null) {
@@ -294,6 +275,10 @@ final class Translator implements LoggerAwareInterface
     {
         $translatedColumns = [];
 
+        if (count($columns) > 0) {
+            $this->ensureValidApiKey();
+        }
+
         try {
             $toTranslateObject = array_intersect_key($record, array_flip($columns));
             $toTranslate = array_filter($toTranslateObject, static fn($value) => is_string($value) && $value !== '');
@@ -408,6 +393,44 @@ final class Translator implements LoggerAwareInterface
         }
 
         return $translatedColumns;
+    }
+
+    /**
+     * Validate the DeepL API key on first use and cache the result on this Translator instance.
+     *
+     * Calling this once a translation is actually about to be attempted (instead of eagerly
+     * at the top of translate()) avoids one DeepL usage HTTP round-trip per record for records
+     * that never reach the translation path (excluded records, records with no translatable
+     * columns, records filtered out by changedFields logic).
+     *
+     * @throws \RuntimeException If the API key has an error, is missing, or has no characters left.
+     */
+    private function ensureValidApiKey(): void
+    {
+        if ($this->deeplApiKeyDetails !== null) {
+            return;
+        }
+
+        $this->deeplApiKeyDetails = DeeplApiHelper::checkApiKey($this->apiKey);
+
+        if ($this->deeplApiKeyDetails['error']) {
+            LogUtility::log($this->logger, 'DeepL API Key is not valid: {error}', [
+                'error' => $this->deeplApiKeyDetails['error'],
+            ]);
+            throw new \RuntimeException('DeepL API Key is not valid: ' . $this->deeplApiKeyDetails['error']);
+        }
+        if (!$this->deeplApiKeyDetails['isValid']) {
+            LogUtility::log($this->logger, 'DeepL API Key is not valid: {error}', [
+                'error' => 'No API Key given.',
+            ]);
+            throw new \RuntimeException('DeepL API Key is not valid: No API Key given.');
+        }
+        if ($this->deeplApiKeyDetails['charactersLeft'] <= 0) {
+            LogUtility::log($this->logger, 'DeepL API Key has no characters left: {charactersLeft}', [
+                'charactersLeft' => $this->deeplApiKeyDetails['charactersLeft'],
+            ]);
+            throw new \RuntimeException('DeepL API Key has no characters left: ' . $this->deeplApiKeyDetails['charactersLeft']);
+        }
     }
 
     private function deeplSourceLanguage(): ?string


### PR DESCRIPTION
Backport of #123 against the `3.x` branch.

## Problem

`Translator::translate()` currently runs `DeeplApiHelper::checkApiKey()` at the very top, which fires a DeepL HTTP usage request for every record that goes through the DataHandler hook — including records that never reach DeepL (excluded records, records where all configured translatable columns are empty, or records that only changed non-translatable fields). A cron run over hundreds of records therefore triggers one unnecessary HTTP round-trip per record, adding several seconds of latency and exposing the installation to transient DeepL API failures even when no translation is attempted.

## Change

* Add a private `Translator::ensureValidApiKey()` helper that caches the `DeeplApiHelper::checkApiKey()` result on a new `?array $deeplApiKeyDetails` instance property, then applies the existing three-branch validation (explicit error, missing key, exhausted quota). Log templates, context keys and exception messages are byte-for-byte identical to the removed inline block so existing structured log consumers keep matching.
* Remove the eager `checkApiKey()` block from the top of `translate()`.
* Call `ensureValidApiKey()` at the top of `translateRecordProperties()`, **before** the surrounding `try { ... } catch (\Exception $e)` block and gated on `count($columns) > 0`. The placement matters: a `RuntimeException` thrown by an invalid key must propagate up so the DataHandler hook can still surface it as a flash message. Inside the existing translation-error `try/catch`, the exception would be swallowed and silently logged per record. The `count($columns) > 0` gate means records whose configured translatable columns have been filtered to zero never touch DeepL — including the usage endpoint.

## Behaviour

Identical to #123, just adapted to the 3.x codebase (no Reflection on TextResult, etc.). Failure visibility preserved: invalid / exhausted keys still raise a `RuntimeException` with the existing message, just slightly later in the call chain.

## Compatibility

* PHP 8.2+ (matches 3.x `composer.json`).
* Public method signatures unchanged.
* Exception messages and log templates unchanged.