### PR TITLE
[3.x] Skip autotranslate DeepL round-trips when no translatable field changed

### DIFF
--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -69,11 +69,24 @@ final class DataHandler implements SingletonInterface
             return;
         }
 
+        // Forward the list of datamap keys so Translator::translate() can
+        // skip DeepL round-trips for the main record when only status fields
+        // (e.g. "hidden" flipped by a cron) have changed. New records pass
+        // null, which keeps the previous "translate everything" behaviour.
+        $changedFields = TranslationHelper::extractChangedFieldsFromDatamap($status, $fields);
+
         $translator = GeneralUtility::makeInstance(Translator::class, $pageId);
 
         try {
             if (in_array($table, TranslationHelper::tablesToTranslate(), true)) {
-                $translator->translate($table, (int)$recordUid, $parentObject);
+                $translator->translate(
+                    $table,
+                    (int)$recordUid,
+                    $parentObject,
+                    null,
+                    Translator::TRANSLATE_MODE_BOTH,
+                    $changedFields
+                );
             }
         } catch (\Exception $e) {
             $flashMessage = GeneralUtility::makeInstance(

--- a/Classes/Utility/TranslationHelper.php
+++ b/Classes/Utility/TranslationHelper.php
@@ -46,6 +46,58 @@ final class TranslationHelper
         return $GLOBALS['TCA'][$table]['ctrl']['transOrigPointerField'] ?? null;
     }
 
+    /**
+     * Derive the list of changed fields from a DataHandler datamap operation.
+     *
+     * New records save a pristine state with every column provided, so the
+     * caller should not reduce the translation scope, null is returned to
+     * signal "translate everything". Updates return the datamap keys, which
+     * are the exact fields that were submitted for this save; downstream
+     * code intersects them with the configured translatable columns to
+     * decide whether a translation is necessary.
+     *
+     * @param string $status DataHandler hook status ('new' or 'update').
+     * @param array $datamap Datamap entry for the current record (fieldArray).
+     * @return string[]|null Null for new records, otherwise the changed field names.
+     */
+    public static function extractChangedFieldsFromDatamap(string $status, array $datamap): ?array
+    {
+        if ($status === 'new') {
+            return null;
+        }
+
+        return array_keys($datamap);
+    }
+
+    /**
+     * Narrow the configured translatable columns to the ones that actually
+     * have to be translated in the current DataHandler operation.
+     *
+     * New records supply a null changed-fields list, which means the whole
+     * configured set is returned (translate everything, as before).
+     * Updates supply the keys of the datamap entry: the result is the
+     * intersection with the configured columns, so a status-only update
+     * (e.g. hidden/starttime) yields an empty list and the caller can
+     * skip the translation call entirely.
+     *
+     * The result preserves the order of $translatableColumns so downstream
+     * processing stays deterministic.
+     *
+     * @param string[] $translatableColumns Columns configured as translatable.
+     * @param string[]|null $changedFields Datamap field names, or null for new records.
+     * @return string[] Empty array = nothing to translate.
+     */
+    public static function filterChangedTranslatableColumns(
+        array $translatableColumns,
+        ?array $changedFields
+    ): array {
+        if ($changedFields === null) {
+            return array_values($translatableColumns);
+        }
+
+        return array_values(array_intersect($translatableColumns, $changedFields));
+    }
+
     public static function unusedTranslateableColumns(string $table, string $value, int $type): array
     {
         $translateableColumns = self::translateableColumns($table);

--- a/Classes/Utility/Translator.php
+++ b/Classes/Utility/Translator.php
@@ -47,7 +47,8 @@ final class Translator implements LoggerAwareInterface
         int $recordUid,
         ?DataHandler $parentObject = null,
         ?string $languagesToTranslate = null,
-        string $translateMode = self::TRANSLATE_MODE_BOTH
+        string $translateMode = self::TRANSLATE_MODE_BOTH,
+        ?array $changedFields = null
     ): void {
         $deeplApiKeyDetails = DeeplApiHelper::checkApiKey($this->apiKey);
         if ($deeplApiKeyDetails['error']) {
@@ -99,6 +100,10 @@ final class Translator implements LoggerAwareInterface
             ], LogUtility::MESSAGE_WARNING);
             return;
         }
+
+        // Narrow the main-record translation to the columns that actually
+        // changed; reference handling below keeps the full configured set.
+        $mainRecordColumns = TranslationHelper::filterChangedTranslatableColumns($columns, $changedFields);
 
         // Set target languages by record if null is given
         if ($languagesToTranslate === null) {
@@ -271,7 +276,7 @@ final class Translator implements LoggerAwareInterface
             }
 
             // Translate properties with given service
-            $translatedColumns = $this->translateRecordProperties($record, (int)$languageId, $columns, $table, $localizedUid);
+            $translatedColumns = $this->translateRecordProperties($record, (int)$languageId, $mainRecordColumns, $table, $localizedUid);
 
             if (count($translatedColumns) > 0) {
                 Records::updateRecord($table, $localizedUid, $translatedColumns);


### PR DESCRIPTION
Backport of #122 against the `3.x` branch.

## Problem

When an editor (or a cron job) saves a record without touching any of the configured translatable fields, a common case is flipping `hidden` on bulk records, the autotranslate hook currently retranslates every configured text column for every target language. Each save causes redundant DeepL round-trips, burns DeepL characters and pollutes the translation cache.

## Change

* `TranslationHelper::extractChangedFieldsFromDatamap($status, $datamap)`: turns the hook `$status` / `$fields` pair into either `null` (new record, translate everything) or the list of datamap keys.
* `TranslationHelper::filterChangedTranslatableColumns($configuredColumns, $changedFields)`: returns the intersection in the configured-column order; an empty result signals 'nothing translatable changed'.
* `Hooks\DataHandler` forwards the changed-fields list to `Translator::translate()` via a new optional `$changedFields` argument.
* `Translator::translate()` intersects the configured translatable columns with the changed fields and passes the narrowed list to `translateRecordProperties()` for the main record only. Reference tables (file references etc.) keep their previous behaviour so editors still see uploaded translations propagate on every save.

## Behaviour

| Scenario | Before | After |
| --- | --- | --- |
| New record | translate all configured columns | unchanged |
| Update, only non-translatable fields changed (e.g. `hidden`) | translate all configured columns ⇒ DeepL call per language | no DeepL call for main record |
| Update, mix of translatable and non-translatable fields | translate all configured columns | translate only the changed translatable columns |
| Reference tables | translate according to their own configured columns | unchanged |

## Compatibility

* PHP 8.2+ (matches 3.x `composer.json`).
* `translate()` adds one optional parameter with a default value, all existing callers (`BatchTranslationService`, `BatchTranslation` command, controllers) keep working unchanged.
* Behaviour on new records is preserved: `extractChangedFieldsFromDatamap('new', ...)` returns `null`, the filter returns the full configured column list.

## Combines cleanly with #129

If #129 (defer checkApiKey) lands first, records with empty `$mainRecordColumns` skip the new `ensureValidApiKey()` call entirely, no DeepL usage HTTP either.