### PR TITLE
[3.x] Respect TCA 'exclude' flag when generating slugs

### DIFF
--- a/Classes/Utility/SlugUtility.php
+++ b/Classes/Utility/SlugUtility.php
@@ -42,7 +42,19 @@ final class SlugUtility
      */
     public static function generateSlug(array $record, string $table, string $field): ?string
     {
-        $fieldConfig = $GLOBALS['TCA'][$table]['columns'][$field]['config'] ?? null;
+        $columnConfig = $GLOBALS['TCA'][$table]['columns'][$field] ?? null;
+
+        if ($columnConfig === null) {
+            return null;
+        }
+
+        // Respect TCA 'exclude' flag, so editors can opt slug fields out of
+        // automatic regeneration when they want to manage them manually.
+        if (($columnConfig['exclude'] ?? false) === true) {
+            return null;
+        }
+
+        $fieldConfig = $columnConfig['config'] ?? null;
 
         if ($fieldConfig === null) {
             return null;


### PR DESCRIPTION
Partial backport of #112 against the `3.x` branch.

## Scope

In 3.x the original PR is mostly redundant:

* The `eval` key access in `SlugUtility::generateSlug()` is gone, the 3.x code already only passes `config` to `SlugHelper`, no string evaluation against `$fieldConfig['eval']` happens.
* The O(n+1) `slugFields()` recomputation in `Translator::generateSlugs()` is gone, the 3.x `generateSlug()` reads directly from `$GLOBALS['TCA'][$table]['columns'][$field]` in a single lookup, so the loop already runs in O(n).

That leaves one behaviour from the main PR that is still relevant on 3.x: **respect the TCA `exclude` flag**, so editors can mark slug fields as opt-out and the DataHandler hook does not regenerate them on every save.

## Change

`SlugUtility::generateSlug()` now returns `null` early when the resolved TCA column has `'exclude' => true`, mirroring the check from #112.

## Behaviour

| Scenario | Before | After |
| --- | --- | --- |
| Slug field without `exclude` flag | regenerate on save | unchanged |
| Slug field with `'exclude' => true` | regenerate on save (overwrites editor's manual value) | skipped, editor value preserved |
| Non-existent field / non-slug field | returns null | unchanged |

## Compatibility

* PHP 8.2+ (matches 3.x `composer.json`).
* Public method signature unchanged.
* No change to callers in `Translator::generateSlugs()`.