### PR TITLE
[3.x] Fix cache roundtrip losing translations

### DIFF
--- a/Classes/Service/TranslationCacheService.php
+++ b/Classes/Service/TranslationCacheService.php
@@ -176,16 +176,17 @@ final class TranslationCacheService
                 $results[$index] = null;
                 continue;
             }
-            
-            // Create TextResult-like object (since TextResult constructor is protected)
-            $result = new class($data['text'], $data['detected_source_lang'], $data['billed_characters']) {
-                public function __construct(
-                    public string $text,
-                    public ?string $detectedSourceLang,
-                    public ?int $billedCharacters,
-                ) {}
-            };
-            $results[$index] = $result;
+
+            // Reconstruct real TextResult objects so serializeTextResults() can
+            // recognise them on the next roundtrip. The previous anonymous-class
+            // implementation failed the instanceof TextResult check there and
+            // got silently serialized as null, causing cache data loss on the
+            // second roundtrip.
+            $results[$index] = new TextResult(
+                $data['text'],
+                $data['detected_source_lang'] ?? '',
+                $data['billed_characters'] ?? 0
+            );
         }
         return $results;
     }


### PR DESCRIPTION
Backport of #111 against the `3.x` branch.

## Root Cause

`unserializeTextResults()` creates anonymous class objects because it assumes `TextResult`'s constructor is protected (see the comment that this PR removes). In fact, the constructor is public:

```php
public function __construct(
    string $text,
    string $detectedSourceLang,
    int $billedCharacters,
    ?string $modelTypeUsed = null
)
```

The anonymous class objects fail the `instanceof TextResult` check in `serializeTextResults()`, so they are serialized as `null`. This causes a silent data loss in this scenario:

1. Partial cache hit: `unserializeTextResults()` returns anonymous class objects.
2. Fresh DeepL translations are fetched for uncached texts: real `TextResult` objects.
3. Both are combined and stored as one cache entry via `setCachedTranslation()`.
4. `serializeTextResults()` converts `TextResult` to the array shape, anonymous class to **null**.
5. Next retrieval returns `null` for previously cached translations.
6. `$v->text` on null triggers `str_replace(): Argument #2 must be array|string, null given`.

## Fix

Replace the anonymous class in `unserializeTextResults()` with real `TextResult` objects:

```php
$results[$index] = new TextResult(
    $data['text'],
    $data['detected_source_lang'] ?? '',
    $data['billed_characters'] ?? 0
);
```

## Compatibility

* PHP 8.2+ (matches 3.x `composer.json`).
* The 3.x `TextResult` import was already present at the top of the file.