### PR TITLE
Fix Fatal Error "contains 7 abstract methods": XClass Configuration does not implement all ConfigurationInterface methods introduced in deepltranslate-core 6.x

### DIFF
--- a/Classes/Xclass/Deepltranslate/Core/Configuration.php
+++ b/Classes/Xclass/Deepltranslate/Core/Configuration.php
@@ -17,6 +17,13 @@ use WebVision\Deepltranslate\Core\ConfigurationInterface;
 final class Configuration implements ConfigurationInterface, SingletonInterface
 {
     private string $apiKey = '';
+    private string $modelType = 'prefer_quality_optimized';
+    private string $splitSentences = 'on';
+    private bool $preserveFormatting = false;
+    private string $ignoreTags = '';
+    private string $nonSplittingTags = '';
+    private string $splittingTags = '';
+    private bool $outlineDetection = true;
 
     /**
      * @throws ExtensionConfigurationPathDoesNotExistException
@@ -43,14 +50,57 @@ final class Configuration implements ConfigurationInterface, SingletonInterface
         }
 
         // fallback to api key from deepltranslate core
+        $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('deepltranslate_core');
         if (!$this->apiKey) {
-            $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('deepltranslate_core');
             $this->apiKey = (string)($extensionConfiguration['apiKey'] ?? '');
         }
+
+        $this->modelType = (string)($extensionConfiguration['modelType'] ?? 'prefer_quality_optimized');
+        $this->splitSentences = (string)($extensionConfiguration['splitSentences'] ?? 'on');
+        $this->preserveFormatting = (bool)($extensionConfiguration['preserverFormatting'] ?? false);
+        $this->ignoreTags = (string)($extensionConfiguration['ignoreTags'] ?? '');
+        $this->nonSplittingTags = (string)($extensionConfiguration['nonSplittingTags'] ?? '');
+        $this->splittingTags = (string)($extensionConfiguration['splittingTags'] ?? '');
+        $this->outlineDetection = (bool)($extensionConfiguration['outlineDetection'] ?? true);
     }
 
     public function getApiKey(): string
     {
         return $this->apiKey;
+    }
+
+    public function getModelType(): string
+    {
+        return $this->modelType;
+    }
+
+    public function getSplitSentences(): string
+    {
+        return $this->splitSentences;
+    }
+
+    public function isPreserveFormattingEnabled(): bool
+    {
+        return $this->preserveFormatting;
+    }
+
+    public function getIgnoreTags(): string
+    {
+        return $this->ignoreTags;
+    }
+
+    public function getNonSplittingTags(): string
+    {
+        return $this->nonSplittingTags;
+    }
+
+    public function getSplittingTags(): string
+    {
+        return $this->splittingTags;
+    }
+
+    public function isOutlineDetectionEnabled(): bool
+    {
+        return $this->outlineDetection;
     }
 }


### PR DESCRIPTION
## Problem
Installing autotranslate alongside deepltranslate-core 6.x causes a Fatal Error
on every page load:

```
Class ThieleUndKlose\Autotranslate\Xclass\Deepltranslate\Core\Configuration
contains 7 abstract methods and must therefore be declared abstract or implement
the remaining methods (ConfigurationInterface::getModelType,
ConfigurationInterface::getSplitSentences, ConfigurationInterface::isPreserveFormattingEnabled, ...)
```

## Steps to reproduce
1. Install autotranslate 2.6.0 and deepltranslate-glossary 6.x (which pulls in
   deepltranslate-core 6.x as a dependency)
2. Open any TYPO3 backend or frontend page

## Root cause
deepltranslate-core 6.x expanded `ConfigurationInterface` with 7 new methods
(`getModelType`, `getSplitSentences`, `isPreserveFormattingEnabled`, `getIgnoreTags`,
`getNonSplittingTags`, `getSplittingTags`, `isOutlineDetectionEnabled`).
The XClass only implements `getApiKey()` and therefore violates the interface contract.

## Fix
Add the 7 missing interface methods to the XClass. They delegate to the
`deepltranslate_core` ExtensionConfiguration — identical to the original
`Configuration.php` implementation.

The fix is backwards-compatible: a class implementing more methods than an older
interface requires (deepltranslate-core 5.x) is valid PHP and causes no issues.

## Tested with
- TYPO3 13.4
- PHP 8.3
- autotranslate 2.6.0
- deepltranslate-core 6.0.2
- deepltranslate-glossary 6.0.0