### PR TITLE
Fix GlossaryService silently skipping glossary for all region-specific target languages (EN-GB, DE-AT, DE-CH, ...)

### DIFF
--- a/Classes/Service/GlossaryService.php
+++ b/Classes/Service/GlossaryService.php
@@ -81,9 +81,12 @@ final class GlossaryService
 
         $pidConstraint = $db->expr()->in('pid', $ids);
 
+        $normalizedSourceLang = strtolower(strlen($sourceLanguage) > 2 ? substr($sourceLanguage, 0, 2) : $sourceLanguage);
+        $normalizedTargetLang = strtolower(strlen($targetLanguage) > 2 ? substr($targetLanguage, 0, 2) : $targetLanguage);
+
         $where = $db->expr()->and(
-            $db->expr()->eq('source_lang', $db->createNamedParameter($sourceLanguage)),
-            $db->expr()->eq('target_lang', $db->createNamedParameter($targetLanguage)),
+            $db->expr()->eq('source_lang', $db->createNamedParameter($normalizedSourceLang)),
+            $db->expr()->eq('target_lang', $db->createNamedParameter($normalizedTargetLang)),
             $db->expr()->in('glossary_id', $db->createNamedParameter($glossaryIds, Connection::PARAM_STR_ARRAY)),
             $pidConstraint
         );


### PR DESCRIPTION
## Problem
The glossary is silently never applied when `deeplTargetLang` in the site config
uses a region-specific code (e.g. `EN-GB`, `EN-US`, `DE-AT`, `DE-CH`). This affects
every translation on those sites.

## Steps to reproduce
1. Configure a site language with `deeplTargetLang: EN-GB`
2. Install deepltranslate-glossary, create a glossary sysfolder with entries
   and synchronize it
3. Trigger a translation — glossary terms are not applied

## Root cause
The DeepL Glossary API only supports 2-char language codes, so
deepltranslate-glossary stores `target_lang` as lowercase 2-char values
(`EN-GB` → `en`, `DE-AT` → `de`). `GlossaryService::getGlossary()` queries with the
raw `deeplTargetLang` value (`EN-GB`), which never matches the stored value (`en`).

## Fix
Normalize source and target language codes to lowercase 2-char before the
`tx_deepltranslate_glossary` query — consistent with how deepltranslate-glossary
stores them on sync.

The fix is backwards-compatible: sites using 2-char codes (`EN`, `DE`) are
unaffected as the normalization is a no-op for strings of length <= 2.

## Tested with
- TYPO3 13.4
- PHP 8.3
- autotranslate 2.6.0
- deepltranslate-core 6.0.2
- deepltranslate-glossary 6.0.0