### PR TITLE
Skip translation for records that no longer exist (2.x)

### DIFF
--- a/Classes/Service/BatchTranslationService.php
+++ b/Classes/Service/BatchTranslationService.php
@@ -144,6 +144,10 @@ class BatchTranslationService implements LoggerAwareInterface
         foreach ($childElements as $childUid) {
             $record = Records::getRecord('tt_content', $childUid);
 
+            if ($record === null) {
+                continue;
+            }
+
             if ($record['CType'] === 'gridelements_pi1') {
                 // If it's a container, translate it and its children recursively
                 $this->translateContainerAndChildren($translator, $constraints, $childUid, $item, $changedFields);
@@ -168,6 +172,10 @@ class BatchTranslationService implements LoggerAwareInterface
 
         foreach ($records as $uid) {
             $record = Records::getRecord('tt_content', $uid);
+
+            if ($record === null) {
+                continue;
+            }
 
             // Skip if it's a Grid-Container or child element
             if ($this->isGridElementOrChild($record)) {

--- a/Classes/Utility/Translator.php
+++ b/Classes/Utility/Translator.php
@@ -90,6 +90,15 @@ class Translator implements LoggerAwareInterface
 
         $record = Records::getRecord($table, $recordUid);
 
+        // exit if record does not exist (e.g. deleted between query and access)
+        if ($record === null) {
+            LogUtility::log($this->logger, 'Record {table}:{uid} not found, skipping translation.', [
+                'table' => $table,
+                'uid' => $recordUid,
+            ], LogUtility::MESSAGE_WARNING);
+            return;
+        }
+
         // exit if record is localized one
         $parentField = TranslationHelper::translationOrigPointerField($table);
         if ($parentField === null || $record[$parentField] > 0) {


### PR DESCRIPTION
2.x port of the null-record guards from #110, as requested in the #111 discussion.

## Problem

A record deleted between the DataHandler queue (or batch list query) and the `translate()` call makes `Records::getRecord()` return `null`. On current 2.x this raises "Trying to access array offset on null" warnings in `Translator::translate()` and a `TypeError` in `hasDeepLTranslationWork(array $record)` further down the chain (the crash reported in #109). In the batch service the same race passes `null` into `isGridElementOrChild(array $record)` and can abort the whole batch run, because the command only catches `\Exception`, not `\Error`.

## Fix

- `Translator::translate()`: return early with a warning log when the record no longer exists.
- `BatchTranslationService::translateContainerAndChildren()` / `translateRegularContent()`: skip null records instead of dereferencing them.

Functional tests covering both scenarios (non-existent uid, soft-deleted record) are part of the main-line PR #110; I left them out here to keep this PR minimal for the 2.x release window.

Fixes #109
