### PR TITLE
Fix translation pi_flexform: Ensure array-keys are of type string

### DIFF
--- a/Classes/Utility/Translator.php
+++ b/Classes/Utility/Translator.php
@@ -711,17 +711,19 @@ class Translator implements LoggerAwareInterface
                     $xml = simplexml_load_string($record['pi_flexform']);
 
                     foreach ($xml->xpath('//field') as $field) {
+                        $fieldname = trim((string) (((array) $field)['@attributes']['index'] ?? ''));
                         $value = (string)$field->value;
                         if (!empty(trim($value))
                             && strpos($value, '<') === false
                             && is_string($value)
                             && !is_numeric($value)
                             && $value !== ''
+                            && str_starts_with($fieldname, 'settings.')
                         ) {
                             $translationResult = $this->translateItems(
                                 $record,
                                 $table,
-                                [$value],
+                                [$fieldname => $value],
                                 $deeplSourceLang,
                                 $deeplTargetLang,
                                 $glossary


### PR DESCRIPTION
Translator::isRichtextField() expects a string for parameter $columnName, therefore passing `[$value]` to translateItems() is problematic.

Fix for:
 (1/1) TypeError
 ThieleUndKlose\Autotranslate\Utility\Translator::isRichtextField(): Argument #3 ($columnName) must be of type string, int given, called in /application/vendor/thieleundklose/autotranslate/Classes/Utility/Translator.php on line 813