### PR TITLE
Cast site-config languageId to int before strict comparison

### DIFF
--- a/Classes/Utility/Translator.php
+++ b/Classes/Utility/Translator.php
@@ -1366,7 +1366,7 @@ class Translator implements LoggerAwareInterface
     private function deeplSourceLanguage(): ?string
     {
         foreach ($this->siteLanguages as $language) {
-            if ($language['languageId'] === 0) {
+            if ((int)$language['languageId'] === 0) {
                 if (empty($language['deeplSourceLang'])) {
                     return null;
                 }
@@ -1384,7 +1384,7 @@ class Translator implements LoggerAwareInterface
     private function deeplTargetLanguage(int $languageId): ?string
     {
         foreach ($this->siteLanguages as $language) {
-            if ($language['languageId'] === $languageId) {
+            if ((int)$language['languageId'] === $languageId) {
                 return $language['deeplTargetLang'] ?? null;
             }
         }


### PR DESCRIPTION
Site configurations may carry the `languageId` as a string (e.g. `'0'`) rather than an int. In that case the strict `===` comparisons in `deeplSourceLanguage()` and `deeplTargetLanguage()` never match, so the source/target DeepL language is not resolved and the record is not translated.

Cast the site-config `languageId` to int before comparing so string and int language ids are treated equally.
