### PR TITLE
Fix invalid page TSconfig condition using frontend-only tree variable (#127)

### DIFF
--- a/Classes/TsConfig/Loader.php
+++ b/Classes/TsConfig/Loader.php
@@ -41,7 +41,7 @@ class Loader
                     continue;
                 }
                 $event->addTsConfig('
-                    [traverse(page, "uid") == ' . $site->getRootPageId() . ' || ' . $site->getRootPageId() . '  in tree.rootLineParentIds]
+                    [site("rootPageId") == ' . $site->getRootPageId() . ']
                         TCAdefaults.' . $table . '.autotranslate_languages = ' . $settings['autotranslateLanguages'] . '
                     [end]
                 ');


### PR DESCRIPTION
The `autotranslate_languages` TCAdefaults are wrapped in the page TSconfig condition:

```
[traverse(page, "uid") == <root> || <root> in tree.rootLineParentIds]
```

The `tree.*` variable only exists in frontend TypoScript, not in the page TSconfig ExpressionLanguage context (which provides only `fullRootLine`, `site`, `page` and `pageId`). Every cold TSconfig build therefore logs:

```
TypoScript condition [...] could not be parsed: Variable "tree" is not valid
```

This is issue #127, reproducible on TYPO3 v12, v13 and v14. Scope the defaults to the site instead:

```
[site("rootPageId") == <root>]
```

which is valid in the page TSconfig context and covers the site root and all its subpages, matching the intent of the original condition.

Note: #127 was closed via 46cd1b0e, but that change only aggregated the `addTsConfig()` calls and kept the `tree.rootLineParentIds` expression, so `main` / 3.x (v3.2.0) still emits the invalid condition. I am happy to open the equivalent fix against the 3.x line as well.

Refs #127
