### PR TITLE
Fix invalid page TSconfig condition using frontend-only tree variable (#127, 3.x)

### DIFF
--- a/Classes/TsConfig/Loader.php
+++ b/Classes/TsConfig/Loader.php
@@ -39,10 +39,9 @@ class Loader
                 }
 
                 $tsConfigBlocks[] = sprintf(
-                    '[traverse(page, "uid") == %d || %d in tree.rootLineParentIds]' . PHP_EOL
+                    '[site("rootPageId") == %d]' . PHP_EOL
                     . '    TCAdefaults.%s.autotranslate_languages = %s' . PHP_EOL
                     . '[END]',
-                    $rootPageId,
                     $rootPageId,
                     $table,
                     $settings['autotranslateLanguages']


### PR DESCRIPTION
3.x counterpart of #143 (which targets 2.x).

The `autotranslate_languages` TCAdefaults are wrapped in the page TSconfig condition `[traverse(page, "uid") == <root> || <root> in tree.rootLineParentIds]`. The `tree.*` variable is only available in frontend TypoScript, not in the page TSconfig ExpressionLanguage context (which exposes only `fullRootLine`, `site`, `page`, `pageId`), so every cold TSconfig build logs `Variable "tree" is not valid` (issue #127).

#127 was closed via 46cd1b0e, but that change only aggregated the `addTsConfig()` calls into a single `implode()` and kept the `tree.rootLineParentIds` expression, so `main` and v3.2.0 still emit the invalid condition. This scopes the defaults to the site with `[site("rootPageId") == <root>]`, valid in the page TSconfig context and covering the site root and all subpages.

Refs #127
